### PR TITLE
Fix horarios generation to use requested date

### DIFF
--- a/backend/app/services/HorariosService.py
+++ b/backend/app/services/HorariosService.py
@@ -37,8 +37,8 @@ def genHorarios(dia: date, medicoId: int):
                 WITH horarios AS (
             SELECT
                 generate_series(
-                    ('2025-09-05 ' || %s)::timestamp,
-                    ('2025-09-05 ' || %s)::timestamp - interval '30 minutes',
+                    (%s::date + %s::time)::timestamp,
+                    (%s::date + %s::time)::timestamp - interval '30 minutes',
                     interval '30 minutes'
                 ) AS hora_inicio
         )
@@ -56,7 +56,7 @@ def genHorarios(dia: date, medicoId: int):
             AND c.hora = hora_inicio::time  -- Verificamos si ya existe una cita a esa hora
         ORDER BY hora_inicio;
     """
-    cursor.execute(query, (hora_inicio, hora_final, medicoId, dia))
+    cursor.execute(query, (dia, hora_inicio, dia, hora_final, medicoId, dia))
     horarios = cursor.fetchall()
     cursor.close()
     conn.close()

--- a/backend/tests/services/test_HorariosService.py
+++ b/backend/tests/services/test_HorariosService.py
@@ -1,12 +1,48 @@
 import pytest
-from datetime import date, time
+from datetime import date, time, datetime, timedelta
 from app.services import HorariosService
+
+
+@pytest.fixture
+def fake_db_factory(monkeypatch):
+    def _factory(*, horas_disponibles=True):
+        class FakeCursor:
+            def __init__(self):
+                self._result = []
+
+            def execute(self, query, params):
+                if "disponibilidad_especialidad" in query:
+                    self._result = [(time(8, 0), time(10, 0))] if horas_disponibles else []
+                else:
+                    self._result = [
+                        (time(8, 0), time(8, 30), True),
+                        (time(8, 30), time(9, 0), False),
+                        (time(9, 0), time(9, 30), True),
+                    ]
+
+            def fetchall(self):
+                return self._result
+
+            def close(self):
+                pass
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(HorariosService, "getConnection", lambda: FakeConnection())
+
+    return _factory
 
 @pytest.mark.parametrize("dia,medico_id", [
     (date(2025, 9, 2), 1),
     (date(2025, 9, 4), 1),
 ])
-def test_genHorarios_formato_y_duracion(dia, medico_id):
+def test_genHorarios_formato_y_duracion(dia, medico_id, fake_db_factory):
+    fake_db_factory(horas_disponibles=True)
     horarios = HorariosService.genHorarios(dia, medico_id)
 
     assert isinstance(horarios, list)
@@ -24,6 +60,63 @@ def test_genHorarios_formato_y_duracion(dia, medico_id):
     (date(2025, 9, 7), 1),
     (date(2025, 9, 6), 2),
 ])
-def test_genHorarios_sin_disponibilidad(dia, medico_id):
+def test_genHorarios_sin_disponibilidad(dia, medico_id, fake_db_factory):
+    fake_db_factory(horas_disponibles=False)
     horarios = HorariosService.genHorarios(dia, medico_id)
     assert horarios == []
+
+
+def test_genHorarios_respeta_parametro_dia(monkeypatch):
+    """Verifica que los horarios generados cambian según la fecha solicitada."""
+
+    captured_params = []
+
+    class FakeCursor:
+        def __init__(self):
+            self._result = []
+
+        def execute(self, query, params):
+            if "disponibilidad_especialidad" in query:
+                self._result = [(time(8, 0), time(10, 0))]
+            else:
+                if not isinstance(params[0], date):
+                    raise AssertionError("Se esperaba que el parámetro dia fuese una fecha")
+                dia = params[0]
+                base_hour = 8 + (dia.day % 3)
+                hora_inicio = time(base_hour, 0)
+                hora_fin = (datetime.combine(dia, hora_inicio) + timedelta(minutes=30)).time()
+                self._result = [(hora_inicio, hora_fin, True)]
+                captured_params.append(params)
+
+        def fetchall(self):
+            return self._result
+
+        def close(self):
+            pass
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(HorariosService, "getConnection", lambda: FakeConnection())
+
+    dia_1 = date(2025, 9, 2)
+    dia_2 = date(2025, 9, 4)
+
+    medico_id = 1
+    horarios_dia_1 = HorariosService.genHorarios(dia_1, medico_id)
+    horarios_dia_2 = HorariosService.genHorarios(dia_2, medico_id)
+
+    assert captured_params and len(captured_params) == 2
+    assert captured_params[0][0] == dia_1
+    assert captured_params[1][0] == dia_2
+
+    def expected_hour(dia):
+        return time(8 + (dia.day % 3), 0)
+
+    assert horarios_dia_1[0]["horaInicio"] == expected_hour(dia_1)
+    assert horarios_dia_2[0]["horaInicio"] == expected_hour(dia_2)
+    assert horarios_dia_1[0] != horarios_dia_2[0]


### PR DESCRIPTION
## Summary
- update `HorariosService.genHorarios` to build the schedule for the requested day instead of a hard-coded date
- refactor the service tests to use a fake database so they no longer depend on a real Postgres instance and add coverage that asserts the day parameter is honored

## Testing
- `pytest backend/tests/services/test_HorariosService.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8aefa6908329a07133be41b60adc)