### PR TITLE
Ensure weekly availability starts on Monday

### DIFF
--- a/backend/app/services/DiasDisponiblesService.py
+++ b/backend/app/services/DiasDisponiblesService.py
@@ -13,8 +13,8 @@ def listarDiasSemana(especialidadId, semanas=1):
 
     # Calcular rango de fechas
     hoy = date.today()
-    inicio_semana = hoy # lunes de esta semana
-    fin_semana = inicio_semana + timedelta(days=7*semanas - 1)
+    inicio_semana = hoy - timedelta(days=hoy.weekday())  # lunes de esta semana
+    fin_semana = inicio_semana + timedelta(days=7 * semanas - 1)
 
     query = """
             WITH rango AS (

--- a/backend/tests/services/test_DiasDisponiblesService.py
+++ b/backend/tests/services/test_DiasDisponiblesService.py
@@ -1,6 +1,41 @@
 import pytest
-from datetime import date
+from datetime import date, timedelta
+
 from app.services import DiasDisponiblesService
+
+
+class DummyCursor:
+    def __init__(self):
+        self._params = None
+
+    def execute(self, query, params):  # pragma: no cover - simple stub
+        self._params = params
+
+    def fetchall(self):  # pragma: no cover - simple stub
+        inicio, fin, _ = self._params
+        dias = []
+        actual = inicio
+        while actual <= fin:
+            dias.append((actual, True))
+            actual += timedelta(days=1)
+        return dias
+
+    def close(self):  # pragma: no cover - simple stub
+        pass
+
+
+class DummyConnection:
+    def cursor(self):  # pragma: no cover - simple stub
+        return DummyCursor()
+
+    def close(self):  # pragma: no cover - simple stub
+        pass
+
+
+@pytest.fixture(autouse=True)
+def mock_db(monkeypatch):
+    monkeypatch.setattr(DiasDisponiblesService, "getConnection", lambda: DummyConnection())
+
 
 @pytest.mark.parametrize("especialidadId,semanas", [
     (1, 1),
@@ -13,3 +48,17 @@ def test_listarDiasSemana_formato_y_longitud(especialidadId, semanas):
     assert len(result) == 7 * semanas
     assert all(isinstance(d["fecha"], date) for d in result)
     assert all(isinstance(d["disponible"], bool) for d in result)
+
+
+def test_listarDiasSemana_inicia_en_lunes(monkeypatch):
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            # Miércoles
+            return date(2024, 2, 7)
+
+    monkeypatch.setattr(DiasDisponiblesService, "date", FakeDate)
+
+    result = DiasDisponiblesService.listarDiasSemana(especialidadId=1, semanas=1)
+
+    assert result[0]["fecha"].weekday() == 0


### PR DESCRIPTION
## Summary
- ensure DiasDisponiblesService calculates the weekly range from the Monday of the current week
- add database stubs to the DiasDisponiblesService tests and add coverage for Monday-based ranges

## Testing
- pytest backend/tests/services/test_DiasDisponiblesService.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b929ec6308329ab48910c99467bcb)